### PR TITLE
Persistently turn off offloading on PIFs, code cleanup

### DIFF
--- a/offloadingoff.sh
+++ b/offloadingoff.sh
@@ -13,68 +13,114 @@
 SLICEID="$1"; 
 
 SLICEOFFLOADINGOFF(){
-	echo "Disabling Offloading for the entire Host";
-		for ETHADP in `ip addr | awk '/eth[0-9]/ {print $2}'|sed 's/://g'`; do ethtool -K ${ETHADP} rx off tx off sg off gso off sgo off tso off; done; 
+	echo -n "Disabling Offloading for the entire Host: ";
+	for ETHADP in $(ifconfig | awk '/^eth[[:digit:]]+[[:blank:]]/ {print $1}' |sed 's/://g') ; do
+		echo -n "${ETHADP} "
+		ethtool -K ${ETHADP} rx off tx off sg off gso off sgo off tso off
+	done
+	echo "done."
 
-	VMUUID=`xe vm-list name-label=${SLICEID} | awk '/uuid/ {print $5}'`; 
+	echo -n "Setting pif-param to make change persistent: "
+	for PIFUUID in $(xe pif-list | awk '/uuid/ {print $5}' | sed '/^$/d') ; do
+		echo -n "${PIFUUID} "
+		xe pif-param-set uuid=$PIFUUID other-config:ethtool-gso="off"
+		xe pif-param-set uuid=$PIFUUID other-config:ethtool-ufo="off"
+		xe pif-param-set uuid=$PIFUUID other-config:ethtool-tso="off"
+		xe pif-param-set uuid=$PIFUUID other-config:ethtool-sg="off"
+		xe pif-param-set uuid=$PIFUUID other-config:ethtool-tx="off"
+		xe pif-param-set uuid=$PIFUUID other-config:ethtool-rx="off"
+	done
+	echo "done."
 
-		echo "Disabling Offloading on the VIF for the specified Instance ID.";
-			for VIFUUID in `xe vif-list vm-uuid=${VMUUID} | awk '/uuid/ {print $5}'|sed '/^$/d'`; do xe vif-param-set uuid=${VIFUUID} other-config:ethtool-gso=”off”; xe vif-param-set uuid=${VIFUUID} other-config:ethtool-ufo=”off”; xe vif-param-set uuid=${VIFUUID} other-config:ethtool-tso=”off”; xe vif-param-set uuid=${VIFUUID} other-config:ethtool-sg=”off”; xe vif-param-set uuid=${VIFUUID} other-config:ethtool-tx=”off”; xe vif-param-set uuid=${VIFUUID} other-config:ethtool-rx=”off”; done; 
+	VMUUID=$(xe vm-list name-label=${SLICEID} | awk '/uuid/ {print $5}')
 
-	echo "All Done..."
+	echo -n "Disabling Offloading on the VIF for the specified Instance ID "
+	for VIFUUID in $(xe vif-list vm-uuid=${VMUUID} | awk '/uuid/ {print $5}' | sed '/^$/d') ; do
+		xe vif-param-set uuid=${VIFUUID} other-config:ethtool-gso=”off”
+		xe vif-param-set uuid=${VIFUUID} other-config:ethtool-ufo=”off”
+		xe vif-param-set uuid=${VIFUUID} other-config:ethtool-tso=”off”
+		xe vif-param-set uuid=${VIFUUID} other-config:ethtool-sg=”off”
+		xe vif-param-set uuid=${VIFUUID} other-config:ethtool-tx=”off”
+		xe vif-param-set uuid=${VIFUUID} other-config:ethtool-rx=”off”
+	done
+
+	echo "done."
 	echo "All of the TCP Offloading for Instace \"${SLICEID}\" that can be off, has been turned off."
 
 	unset VMUUID;
-unset SLICEID; 
+	unset SLICEID; 
 
 }
 
 ALLOFFLOADINGOFF(){
-	echo "Disabling Offloading for the entire Host";
-		for ETHADP in `ip addr | awk '/eth[0-9]/ {print $2}'|sed 's/://g'`; do ethtool -K ${ETHADP} rx off tx off sg off gso off sgo off tso off; done; 
+	echo -n "Disabling Offloading for the entire Host: ";
+	for ETHADP in $(ifconfig | awk '/^eth[[:digit:]]+[[:blank:]]/ {print $1}' | sed 's/://g') ; do
+		echo -n "${ETHADP} "
+		ethtool -K ${ETHADP} rx off tx off sg off gso off sgo off tso off
+	done
+	echo "done."
 
-for INSTANCEID in `xe vm-list | awk '/name-label/' | grep -v 'Control domain' | awk '{print $4}'` 
+	echo -n "Setting pif-param to make change persistent: "
+	for PIFUUID in $(xe pif-list | awk '/uuid/ {print $5}' | sed '/^$/d') ; do
+		echo -n "${PIFUUID} "
+		xe pif-param-set uuid=$PIFUUID other-config:ethtool-gso="off"
+		xe pif-param-set uuid=$PIFUUID other-config:ethtool-ufo="off"
+		xe pif-param-set uuid=$PIFUUID other-config:ethtool-tso="off"
+		xe pif-param-set uuid=$PIFUUID other-config:ethtool-sg="off"
+		xe pif-param-set uuid=$PIFUUID other-config:ethtool-tx="off"
+		xe pif-param-set uuid=$PIFUUID other-config:ethtool-rx="off"
+	done
+	echo "done."
 
-do 
-	VMUUID=`xe vm-list name-label=${INSTANCEID}|awk '/uuid/ {print $5}'`; 
-		echo "Offloading done on \"${INSTANCEID}\""
-			for VIFUUID in `xe vif-list vm-uuid=${VMUUID} | awk '/uuid/ {print $5}'|sed '/^$/d'`; do xe vif-param-set uuid=${VIFUUID} other-config:ethtool-gso=”off”; xe vif-param-set uuid=${VIFUUID} other-config:ethtool-ufo=”off”; xe vif-param-set uuid=${VIFUUID} other-config:ethtool-tso=”off”; xe vif-param-set uuid=${VIFUUID} other-config:ethtool-sg=”off”; xe vif-param-set uuid=${VIFUUID} other-config:ethtool-tx=”off”; xe vif-param-set uuid=${VIFUUID} other-config:ethtool-rx=”off”; done; 
+	for INSTANCEID in $(xe vm-list | awk '/name-label/' | grep -v 'Control domain' | awk '{print $4}') ; do
+		VMUUID=$(xe vm-list name-label=${INSTANCEID} | awk '/uuid/ {print $5}')
+		echo -n "Disabling offloading on instance \"${INSTANCEID}\" "
+		for VIFUUID in $(xe vif-list vm-uuid=${VMUUID} | awk '/uuid/ {print $5}'| sed '/^$/d') ; do
+			xe vif-param-set uuid=${VIFUUID} other-config:ethtool-gso=”off”
+			xe vif-param-set uuid=${VIFUUID} other-config:ethtool-ufo=”off”
+			xe vif-param-set uuid=${VIFUUID} other-config:ethtool-tso=”off”
+			xe vif-param-set uuid=${VIFUUID} other-config:ethtool-sg=”off”
+			xe vif-param-set uuid=${VIFUUID} other-config:ethtool-tx=”off”
+			xe vif-param-set uuid=${VIFUUID} other-config:ethtool-rx=”off”
+		done
+		echo "done."
 
-		unset VMUUID;
-	unset INSTANCEID; 
-done;
+		unset VMUUID
+		unset INSTANCEID
+	done
 
 	echo "All Done..."
 	echo "All of the TCP Offloading for ALL Instances that can be off, has been turned off."
 }
 
-if [ -z "$SLICEID" ];then 
-	echo ""; 
+if [ -z "$SLICEID" ] ; then 
+	echo "" 
 	clear
 	echo -e "No Command Given, \033[1;31m ** FAIL ** \033[0m";
-	echo -e "Use : \033[1;31mxe vm-list\033[0m to see all active Instances. and then provide a Valid Instance ID.";
-	echo -e "If you would like to disable \033[1;31mALL\033[0m Offloading for \033[1;31mALL\033[0m VM's use the \033[1;31mALL\033[0m Command.";
-	echo '';
+	echo -e "Use : \033[1;31mxe vm-list\033[0m to see all active Instances. and then provide a Valid Instance ID."
+	echo -e "If you would like to disable \033[1;31mALL\033[0m Offloading for \033[1;31mALL\033[0m VM's use the \033[1;31mALL\033[0m Command."
+	echo ''
+	exit 1
+elif [ $1 == "ALL" ] ; then
+	echo ''
+	echo -e "This will disable \033[1;31mALL\033[0m TCP Offloading for the entire host on \033[1;31mALL\033[0m Instances."
+	read -p "If this is what you intended to do, then press [ Enter ] to continue.  If not Press [ CTRL - C ]"
+	echo ''
+	ALLOFFLOADINGOFF
+	exit 0
+else
+
+	if [ ! $(xe vm-list|awk '/name-label/ {print $4}' | grep ${SLICEID}) ] ; then
+		echo ''
+		echo -e "\033[1;31mNo Slice Found, FAILED\033[0m"
+		echo "The Instance ID you entered was not found."
+		echo -e "Use : \033[1;31mxe vm-list\033[0m to see all active Instances."
+		echo ''
 		exit 1
-			elif [ $1 == "ALL" ];then
-			echo ''
-			echo -e "This will disable \033[1;31mALL\033[0m TCP Offloading for the entire host on \033[1;31mALL\033[0m Instances."
-			read -p "If this is what you intended to do, then press [ Enter ] to continue.  If not Press [ CTRL - C ]"
-			echo ''
-				ALLOFFLOADINGOFF
-					exit 0
-else 
+	fi
 
-          if [ ! `xe vm-list|awk '/name-label/ {print $4}'|grep ${SLICEID}` ];then 
-				echo '';echo -e "\033[1;31mNo Slice Found, FAILED\033[0m"; 
-				echo "The Instance ID you entered was not found.";
-				echo -e "Use : \033[1;31mxe vm-list\033[0m to see all active Instances.";
-				echo '';
-					exit 1
-          fi;
-
-				SLICEOFFLOADINGOFF
-					exit 0
+	SLICEOFFLOADINGOFF
+	exit 0
 
 fi
 


### PR DESCRIPTION
I changed the script so that it does not only run ethtool to the PIFs but also runs 'xe pif-param-set' to make the change persistent.

I also cleaned up the code a bit. Most importantly, the AWK regex will no longer match physical VLAN interfaces which resulted in a warning from ethtool.
